### PR TITLE
Initial draft of the Senior Engineer skills list

### DIFF
--- a/Engineering.md
+++ b/Engineering.md
@@ -2,9 +2,35 @@
 
 These roles start after Senior Developer, as a more technically-focused career path.
 
+Being technical does not eliminate the need to utilise soft skills, as you will still be dealing with people and need to be able to explain concepts across all levels of a business as well as at various events.  
+
 ## Senior Engineer
-> I am a senior developer with a specific technical speciality, an architect and a problem solver. I am the go-to person in my technology area. I represent the technical brilliance that Readify brings to the market.
+> I am a consultant with a specific technical speciality, an architect, and a communicator and a problem solver. I am the go-to person in my technology area and am known outside of Readify for it. I represent the technical brilliance that Readify brings to the market.
 
-This is a proposed role. We'll need to flesh out the details of it here yet.
+#### I am known for my deep knowledge in my area(s) of specialisation  
+- I have extensive community engagement via my specialisation area. This may include speaking at conferences and user groups, writing books or blog posts, answering StackOverflow or forum questions, being an MVP or more.
+- I contribute to open source projects related to my specialisation and/or I am a greatly desired team member for Readify projects that require skillz in my area of specialisation.
+- Customers seek out Readify because of my reputation.
+- Internally, my Readify colleagues regard me as an expert in my area of specialisation and ask for my advice.
 
-It's intended to be overall roughly equivalent to Senior Consultant, but with more of an engineering focus.
+#### I am broader than my specialisation and more than a Senior Developer
+- I have a wide understanding of software development technology and practices, backed by extensive practical experience.
+- I am confident making architectural decisions taking concerns like infrastructure, identity management, security, scalability, performance, concurrency and maintainability into consideration.
+- I am comfortable with transparently assessing risk, making recommendations, escalating appropriately and dealing with the consequences along the way.
+- I can apply my technical abilities to productively solve business problems outside of my specialisation area with confidence and pragmatism.
+- I am comfortable with building a product vision with a customer based on their business needs, regardless of whether this involves technology or otherwise.
+- I have the skillz, speed and knowledge that enables me to consitently be one of the most productive team members of any team I am part of.
+- I understand that while my specialisation may be a hammer in my toolkit, not every problem is a nail. I know when to propose alternate solutions that can solve the business need without using my deeply specialised skills.
+
+#### I communicate technical concepts confidently and clearly
+- I have developed strong presentation skills and am able to tailor my content and conversation to the audience.
+- I am able to talk confidently about alternative solutions in my specialisation area. I can position the pros and cons of those solutions in terms of business costs and benefits rather than technical purity.
+- I am able to solve deeply complex technical problems using my specialist skillz creating highly maintainable software. I can communicate the design of these solutions to others in a way that they can grasp and understand.
+- I can confidently position ideas and solutions to problems and influence my team and my customer's decisions.
+
+#### I am always learning, always teaching, always collaborating
+- I am constantly looking for opportunities and ways to impart my knowledge to others.
+- I may be a highly regarded engineer but I don't know everything, even when my ego wants to pretend I do. I am comfortable showing that I still need to learn and will visibly collaborate, seek help, get advice, and undertake mentoring as needed.
+- I am an information sponge, always staying abreast of advances in both my specialty area and the broader sofwtare development ecosystem.
+- I know that my knowledge will soon be obsolete so I'm actively investing in at least one other area or technology into which I can grow and specialise.
+- I am proficient at delivering software products using agile practices.


### PR DESCRIPTION
Some thinking behind the wording

1. Describing the SE role in a way that matches the high level description and radar chart [on the intranet](https://readify.sharepoint.com/the-way-we-work/Pages/Consulting%20Roles.aspx)
1. Make sure the SE is defined as a "best of the best" role within Readify, with a technical focus. Our elite Special Forces members who embody all that Readify stands for, but who don't want to head down a team leadership path.
1. Avoid defining a tech/soluton architect role or restating the old psuedo-role of Tech Specialist, even though the TS skills are a central part of this new SE role.
1. Make it clear that the SE role needs awesome soft skills, and differentiate it enough from an SD role so that people don't expect a promotion to SE simply because they've been in the SD role for a while and are pretty good at just coding.
1. Indicate that an SE needs much deeper & broader skills and knowledge than an SD does, as well as having a specialisation. This will ensure we don't have SEs who are awesome at one thing, and only one thing, and can't really contribute anywhere else. We still need to be able to sell these people into gigs outside their deep specialisation.

So have a look, see what's been missed and where the wording is a little too vague.

The flood gates are open! :-)
