### PR TITLE
renamed delivery manager

### DIFF
--- a/ProgramManager.md
+++ b/ProgramManager.md
@@ -1,6 +1,4 @@
-#Delivery Roles
-
-##Delivery Manager
+##Program Manager
 
 > I provide sound, reasoned governance that meets the needs of my customers while remaining flexible enough to get things done.
 
@@ -39,4 +37,4 @@
 
 - I take time to reflect on our identity, our people and our culture as Readify, and the way in which we work and how we deliver our engagements. 
 - I think of ways in which we can improve ourselves, engage others to validate those ideas and then invest time in implementing them.
-- I am actively building my brand as a delivery manager within Readify and our customers 
+- I am actively building my brand as a program manager within Readify and our customers 


### PR DESCRIPTION
The artist formerly known as "Delivery Manager" is not "Program Manager". This is confusing because "Delivery Manager" is now something else.