### PR TITLE
Remove development references from SE

### DIFF
--- a/Engineering.md
+++ b/Engineering.md
@@ -16,7 +16,7 @@ Being technical does not eliminate the need to utilise soft skills, as you will 
 - I can adapt to a given situation and can learn and implement new technologies with very short notice.
 
 #### I am more than a Senior Developer
-- I have a wide understanding of software development technology and practices, backed by extensive practical experience.
+- I have a wide understanding of technology and technology practices, backed by extensive practical experience.
 - I am confident making architectural decisions taking concerns like infrastructure, identity management, security, scalability, performance, concurrency and maintainability into consideration.
 - I am comfortable with transparently assessing risk, making recommendations, escalating appropriately and dealing with the consequences along the way.
 - I can apply my technical abilities to productively solve business problems with confidence and pragmatism.
@@ -26,12 +26,11 @@ Being technical does not eliminate the need to utilise soft skills, as you will 
 #### I communicate technical concepts confidently and clearly
 - I have developed strong presentation skills and am able to tailor my content and conversation to the audience.
 - I am able to talk confidently about alternative solutions. I can position the pros and cons of those solutions in terms of business costs and benefits rather than technical purity.
-- I am able to solve deeply complex technical problems creating highly maintainable software. I can communicate the design of these solutions to others in a way that they can grasp and understand.
+- I am able to solve deeply complex technical problems creating highly maintainable systems. I can communicate the design of these solutions to others in a way that they can grasp and understand.
 - I can confidently position ideas and solutions to problems and influence my team and my customer's decisions.
 
 #### I am always learning, always teaching, always collaborating
 - I am constantly looking for opportunities and ways to impart my knowledge to others.
 - I may be a highly regarded engineer but I don't know everything, even when my ego wants to pretend I do. I am comfortable showing that I still need to learn and will visibly collaborate, seek help, get advice, and undertake mentoring as needed.
-- I am an information sponge, always staying abreast of advances in software development ecosystem.
+- I am an information sponge, always staying abreast of advances in technology.
 - I know that my knowledge will soon be obsolete so I'm actively investing in other areas or technologies into which I can grow.
-- I am proficient at delivering software products using agile practices.


### PR DESCRIPTION
As part of work on #50, modifying Senior Engineer to reduce development references. I have removed the agile reference, this can be reintroduced once change management wording is agreed upon.