### PR TITLE
Clarify managed services path

### DIFF
--- a/Consulting.md
+++ b/Consulting.md
@@ -95,10 +95,14 @@
 - I happily take responsibility for my own mistakes and I learn from the mistakes of others.
 
 
-## Engineering Branch
+----------
+## 🔀 Other Pathways
 
-At this point, some people may choose to take the [engineering branch](Engineering.md).
+At this point, some people may choose to take the [engineering branch](./Engineering.md).
 
+[Managed services](./Managed%20Services.md) roles also differ slightly after this point.
+
+----------
 
 ## Senior Consultant
 > I am a well-rounded developer, architect, problem solver and leader of people. I represent the value Readify brings to the market.

--- a/Managed Services.md
+++ b/Managed Services.md
@@ -1,5 +1,15 @@
 # Managed Services Roles
 
+The managed services career path starts out with the same roles as the [Consulting](./Consulting.md) path. 
+
+In the interests of keeping things DRY, these roles' content are linked rather than copy-pasted.
+
+## [Graduate Developer](./Consulting.md#graduate-developer)
+
+## [Developer](./Consulting.md#developer)
+
+## [Senior Developer](./Consulting.md#senior-developer) 
+
 ## Technical Lead
 > I am a well-rounded developer, problem solver and mentor for people. I represent the unconventional value Readify brings to the market.
 


### PR DESCRIPTION
Funnily enough, Managed Services doesn't start with Technical Leads.

Make it clearer that MS branches to its own file after the first 3 consulting roles, and ensure that the Managed Services.md file can stand on its own with links off to the content of the first 3 roles.