### PR TITLE
Remove "other pathways" heading from design roles

### DIFF
--- a/InnovationAndDesign.md
+++ b/InnovationAndDesign.md
@@ -112,11 +112,6 @@
 - I am actively introspective and take time to work on my personal and professional development.
 - I happily take responsibility for my own mistakes and I learn from the mistakes of others.
 
-
-## Other Pathways
-
-There are no other pathways. All designers are consultants.
-
 ## Senior Experience Design Consultant
 > I am a well-rounded researcher, designer, problem solver and leader of people. I represent the value Readify brings to the market.
 


### PR DESCRIPTION
This heading is needed in the Development roles because they 'fork' to Engineering. Design doesn't have a fork, so the heading doesn't make sense.